### PR TITLE
Fix nginx config

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,16 +12,16 @@ location __PATH__/ {
     more_set_headers "X-XSS-Protection: '1; mode=block'";
     more_set_headers "Content-Security-Policy: frame-ancestors 'self'";
 
+    # assets can be cached because they have hashed filenames
+    location __PATH__/assets {
+        expires 1w;
+        more_set_headers "Cache-Control: 'public, no-transform'";
+    }
+
+    location __PATH__/apple-app-site-association {
+       default_type application/json;
+    }
+    
     # Include SSOWAT user panel.
     include conf.d/yunohost_panel.conf.inc;
-}
-
-# assets can be cached because they have hashed filenames
-location __PATH__/assets {
-    expires 1w;
-    more_set_headers "Cache-Control: 'public, no-transform'";
-}
-
-location __PATH__/apple-app-site-association {
-    default_type application/json;
 }


### PR DESCRIPTION
Fixes https://ci-apps-bullseye-dev.yunohost.org/ci/job/20989 ?

```
2024/11/25 19:09:10 [error] 3726#3726: *2 open() "/usr/share/nginx/html/assets/index-DPxD4Aoi.css" failed (2: No such file or directory), client: 10.131.27.1, server: sub.domain.tld, request: "GET /assets/index-DPxD4Aoi.css HTTP/2.0", host: "sub.domain.tld"
2024/11/25 19:09:10 [error] 3726#3726: *3 open() "/usr/share/nginx/html/assets/index-D8ZN97es.js" failed (2: No such file or directory), client: 10.131.27.1, server: sub.domain.tld, request: "GET /assets/index-D8ZN97es.js HTTP/2.0", host: "sub.domain.tld"
```

This indicates assets are searched in default nginx location, not the one from `alias`.