### PR TITLE
Update nginx.conf to allow use in element web

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -7,10 +7,8 @@ location __PATH__/ {
     
     index index.html;
 
-    more_set_headers "X-Frame-Options: SAMEORIGIN";
     more_clear_headers "X-Content-Type-Options";
     more_set_headers "X-XSS-Protection: '1; mode=block'";
-    more_set_headers "Content-Security-Policy: frame-ancestors 'self'";
 
     # assets can be cached because they have hashed filenames
     location __PATH__/assets {


### PR DESCRIPTION
I had to remove these lines from nginx to allow for element web to embed and use the custom instance.

It could be more securely implemented with an install option to ask for the element web domain, then setting that in `more_set_headers "Content-Security-Policy: frame-ancestors '__ELEMENT_WEB_DOMAIN__'";` but I don't have the time to try do that :)

(Might close #36 but not too sure what exactly they're asking)