### PR TITLE
Upgrade to v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**Shipped version:** 0.7.2~ynh1
+**Shipped version:** 0.8.0~ynh1
 
 **Demo:** <https://call.element.io/>
 

--- a/README_es.md
+++ b/README_es.md
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**Versión actual:** 0.7.2~ynh1
+**Versión actual:** 0.8.0~ynh1
 
 **Demo:** <https://call.element.io/>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**Paketatutako bertsioa:** 0.7.2~ynh1
+**Paketatutako bertsioa:** 0.8.0~ynh1
 
 **Demoa:** <https://call.element.io/>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Appels de groupe avec WebRTC qui exploitent Matrix et une boîte à outils WebRTC open source de LiveKit.
 
 
-**Version incluse :** 0.7.2~ynh1
+**Version incluse :** 0.8.0~ynh1
 
 **Démo :** <https://call.element.io/>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**Versión proporcionada:** 0.7.2~ynh1
+**Versión proporcionada:** 0.8.0~ynh1
 
 **Demo:** <https://call.element.io/>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**Versi terkirim:** 0.7.2~ynh1
+**Versi terkirim:** 0.8.0~ynh1
 
 **Demo:** <https://call.element.io/>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**Geleverde versie:** 0.7.2~ynh1
+**Geleverde versie:** 0.8.0~ynh1
 
 **Demo:** <https://call.element.io/>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**Dostarczona wersja:** 0.7.2~ynh1
+**Dostarczona wersja:** 0.8.0~ynh1
 
 **Demo:** <https://call.element.io/>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**Поставляемая версия:** 0.7.2~ynh1
+**Поставляемая версия:** 0.8.0~ynh1
 
 **Демо-версия:** <https://call.element.io/>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Group calls with WebRTC that leverage Matrix and an open-source WebRTC toolkit from LiveKit.
 
 
-**分发版本：** 0.7.2~ynh1
+**分发版本：** 0.8.0~ynh1
 
 **演示：** <https://call.element.io/>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Element-Call"
 description.en = "Group calls powered by Matrix"
 description.fr = "Appels de groupe alimentés par Matrix"
 
-version = "0.7.2~ynh1"
+version = "0.8.0~ynh1"
 
 maintainers = []
 
@@ -51,8 +51,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/vector-im/element-call/archive/refs/tags/v0.7.2.tar.gz"
-    sha256 = "2cc8a9267ee901340bd8b3b9066618173b8cfadbf2a4de9e936ba59a5c1d88d0"
+    url = "https://github.com/vector-im/element-call/archive/refs/tags/v0.8.0.tar.gz"
+    sha256 = "c55ae35113c2da19128eed9b85ff81e0edd58f07b215863107d16593a2ac3900"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]


### PR DESCRIPTION
Upgrade sources
- `main` v0.8.0: https://github.com/vector-im/element-call/releases/tag/0.8.0

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
